### PR TITLE
Add Node v0.12.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ monitor.on('change:vid:pid', function(err, devices) {});
 
 # Release Notes
 
+## v1.1.0
+
+ - Add support for Node v0.12.x
+
 ## v1.0.3
 
 - revert "ready for node >= 0.11.4"

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,9 @@
         "src/detection.h",
         "src/deviceList.cpp"
       ],
+      "include_dirs" : [
+        "<!(node -e \"require('nan')\")"
+      ],
       'conditions': [
         ['OS=="win"',
           {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usb-detection",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "List USB devices in system and detect changes on them.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "main": "index.js",
   "dependencies": {
     "bindings": "1.1.0",
-    "eventemitter2": ">=0.4.11"
+    "eventemitter2": ">=0.4.11",
+    "nan": "^1.8.4"
   },
   "gypfile": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "preinstall": "node-gyp rebuild"
+    "postinstall": "node-gyp rebuild"
   },
   "repository": {
     "type": "git",
@@ -19,6 +20,7 @@
   "keywords": [
     "usb",
     "list",
+    "insert",
     "add",
     "remove",
     "change",

--- a/src/detection.h
+++ b/src/detection.h
@@ -4,37 +4,40 @@
 
 #include <node.h>
 #include <v8.h>
+#include <uv.h>
 #include <list>
 #include <string>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <nan.h>
 
 #include "deviceList.h"
 
-v8::Handle<v8::Value> Find(const v8::Arguments& args);
+void Find(const v8::FunctionCallbackInfo<v8::Value>& args);
 void EIO_Find(uv_work_t* req);
 void EIO_AfterFind(uv_work_t* req);
 void InitDetection();
-v8::Handle<v8::Value> StartMonitoring(const v8::Arguments& args);
+void StartMonitoring(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Start();
-v8::Handle<v8::Value> StopMonitoring(const v8::Arguments& args);
+void StopMonitoring(const v8::FunctionCallbackInfo<v8::Value>& args);
 void Stop();
 
 
 struct ListBaton 
 {
 public:
-  v8::Persistent<v8::Value> callback;
+  //v8::Persistent<v8::Function> callback;
+	NanCallback* callback;
   std::list<ListResultItem_t*> results;
   char errorString[1024];
   int vid;
   int pid;
 };
 
-v8::Handle<v8::Value> RegisterAdded(const v8::Arguments& args);
+void RegisterAdded(const v8::FunctionCallbackInfo<v8::Value>& args);
 void NotifyAdded(ListResultItem_t* it);
-v8::Handle<v8::Value> RegisterRemoved(const v8::Arguments& args);
+void RegisterRemoved(const v8::FunctionCallbackInfo<v8::Value>& args);
 void NotifyRemoved(ListResultItem_t* it);
 
 #endif


### PR DESCRIPTION
Add Node v0.12.x support.

Fixes KABA-CCEAC/node-usb-detection#6

 - Upgraded all native addon C++ calls.
 - Used [nan](https://www.npmjs.com/package/nan)

---

You can depend on it now until the PR gets merged.

```
npm install git://github.com/MadLittleMods/node-usb-detection.git#add-node-v0.12.x-support --save
```